### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: android
+android:
+  components:
+    - platform-tools
+    - tools
+    - extra-android-m2repository
+    - build-tools-23.0.1
+    - android-21
+    - android-23
+    - sys-img-armeabi-v7a-android-21
+# Emulator Management: Create, Start and Wait
+before_script:
+  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+script: ./gradlew connectedAndroidTest

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 XTime for Android
 =================
 
+[![Build Status](https://travis-ci.org/smuldr/xtime-android.svg?branch=master)](https://travis-ci.org/smuldr/xtime-android)
+
 Android client for the [Xebia Time Tracking System](https://xtime.xebia.com/).
-
-## Requirements and dependencies
-
-- Android Build Tools version 20.0.0
-- Gradle version 1.12 (Gradle wrapper is included in the project)
-- Android support library v13 20.0.0 (for Fragment compatibility)
-- OkHttp library 2.0.0
 
 ## Project structure
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    // latest build tools version in Travis CI is 23.0.1
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 15


### PR DESCRIPTION
Load the required Android components, builds the project and runs the tests on an emulator. The Android 23 emulator gave timeout issues, so we use Android 21 instead.